### PR TITLE
Better <head/> tag description

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,7 +11,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={siteConfig.title}
-      description="Description will go into a meta tag in <head />"
+      description="Scale Bitcoin, save fees, and preserve privacy all at once."
     >
       <main className="text-center bg-secondary">
         <div className="flex flex-col items-center max-sm:gap-20">


### PR DESCRIPTION
Copied the site description on the landing page into the `<head />` description so that we have an actual abbreviation description when sending the site to people via text for example, instead of the template description. Happy to discuss if we want it to be something else but anything is better than the template