### PR TITLE
Update deploy-pages & upload-pages-artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           touch build/.nojekyll
 
       - name: Upload Artifacts
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # this should match the `pages` option in your adapter-static options
           path: 'build/'
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Github action upload-pages-artifact is deprecated, and doesn't work with actions/deploy-pages@v1. Updated upload-pages-artifact to v3 and deploy-pages to v4 to fix our failing deployments.

See [here](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0)